### PR TITLE
Remove about page from navbar, and make Committees unclickable

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,30 +3,32 @@
         <a href="{{ site.baseurl }}/">{% include 'ucla-acm-logo.svg' %}</a>
     </div>
     <div class="links">
-    {% for node in collections.nav %}
+        {% for node in collections.nav %}
         {% if node.data.title == "Committees" %}
 
-            <div class="navigation-committee">
-                {% if page.url == node.url %}
-                    <div class ="dropbtn"><a href="{{{{ node.url | prepend: site.baseurl }}" class="active">{{ node.data.title }}</a></div>
-                {% else %}
-                    <div class ="dropbtn"><a href="{{{{ node.url | prepend: site.baseurl }}" class="not-active">{{ node.data.title }}</a></div>
-                {% endif %}
-                <div id="dropdown" class="dropdown-content">
-                    {% for committee in committees %}
-                        <script>console.log("{{ committee.filename }}")</script>
-                        {% if page.url contains committee.filename %}
-                            <a href="{{ site.baseurl }}/committees/{{ committee.filename }}/" class="active-{{ committee.filename | downcase}}">{{ committee.title }}</a>
-                        {% else %}
-                            <a href="{{ site.baseurl }}/committees/{{ committee.filename }}/"  class="committee-not-active">{{ committee.title }}</a>
-                        {% endif %}
-                    {% endfor %}
-                </div>
-            </div>
-        
-        {% else %}
+        <div class="navigation-committee">
             {% if page.url == node.url %}
-                <a href="{{{{ node.url | prepend: site.baseurl }}" class="active">{{ node.data.title }}</a>
+            <div class="dropbtn">{{ node.data.title }}</div>
+            {% else %}
+            <div class="dropbtn">{{ node.data.title }}</div>
+            {% endif %}
+            <div id="dropdown" class="dropdown-content">
+                {% for committee in committees %}
+                <script>console.log("{{ committee.filename }}")</script>
+                {% if page.url contains committee.filename %}
+                <a href="{{ site.baseurl }}/committees/{{ committee.filename }}/"
+                    class="active-{{ committee.filename | downcase}}">{{ committee.title }}</a>
+                {% else %}
+                <a href="{{ site.baseurl }}/committees/{{ committee.filename }}/"
+                    class="committee-not-active">{{ committee.title }}</a>
+                {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+
+        {% else %}
+        {% if page.url == node.url %}
+        <a href="{{{{ node.url | prepend: site.baseurl }}" class="active">{{ node.data.title }}</a>
             {% else %}
                 <a href="{{{{ node.url | prepend: site.baseurl }}" class="not-active">{{ node.data.title }}</a>
             {% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,7 +10,7 @@ css_links: ['/css/master.css']
 {%- endif -%}
 
 <!DOCTYPE HTML>
-<html>
+<html style="overflow-x: hidden;">
     <head>
         <meta charset="utf-8">
         <meta name="description" content="{{ desc }}">

--- a/_pages/02_about.md
+++ b/_pages/02_about.md
@@ -2,7 +2,6 @@
 layout: page
 title: About
 permalink: "/about/"
-tags: nav
 date: 2000-01-01
 ---
 

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -71,6 +71,7 @@
     }
   }
   &:hover .dropdown-content {display: block;}
+  &:active .dropdown-content {display: block;}
 }
 
 /* 'acm at UCLA' logo */

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -163,7 +163,6 @@ body {
   }
 
   .image-full-width {
-    height: 45rem;
     object-fit: cover;
     width: 100vw;
     position: relative;

--- a/css/master.css
+++ b/css/master.css
@@ -136,7 +136,6 @@ body {
     max-width: 150px;
     margin: 0 auto; }
   .content-body .image-full-width {
-    height: 45rem;
     object-fit: cover;
     width: 100vw;
     position: relative;
@@ -737,6 +736,8 @@ body {
       .navigation-committee .dropdown-content a:hover {
         opacity: 0.7; }
   .navigation-committee:hover .dropdown-content {
+    display: block; }
+  .navigation-committee:active .dropdown-content {
     display: block; }
 
 /* 'acm at UCLA' logo */


### PR DESCRIPTION
Hid "About" and "Committees" page from the navbar: closes #49 #50  